### PR TITLE
修复了拖拽视频后播放黑屏问题

### DIFF
--- a/src/components/item/trackItem/template/trackCheckPlaying.ts
+++ b/src/components/item/trackItem/template/trackCheckPlaying.ts
@@ -1,11 +1,16 @@
 import { usePlayerState } from '@/stores/playerState';
 import { watchEffect, onBeforeUnmount } from 'vue';
+import { isEqual } from 'lodash-es';
+
 export default function setup(props: Record<string, any>) {
     const store = usePlayerState();
     watchEffect(() => {
         const trackItem = props.trackItem;
         if (store.playStartFrame >= trackItem.start && store.playStartFrame <= trackItem.end) {
-            !store.playTargetTrackMap.has(trackItem.id) && store.playTargetTrackMap.set(trackItem.id, trackItem);
+            const oldPlayTargetTrackMap = store.playTargetTrackMap.get(trackItem.id);
+            if (!oldPlayTargetTrackMap || !isEqual(oldPlayTargetTrackMap, trackItem)) {
+                store.playTargetTrackMap.set(trackItem.id, trackItem);
+            }
         } else {
             store.playTargetTrackMap.has(trackItem.id) && store.playTargetTrackMap.delete(trackItem.id);
         }


### PR DESCRIPTION
修复了拖拽视频后播放黑屏问题

播放黑屏复现步骤：
拖动一个视频到轨道并播放，然后拉伸视频的长度，这时播放后，上面会显示黑屏。
修复：
在 setup 时，除了比较是否存在这个视频信息外，还需要比较里面每个数值是否相等，不相等则重新设置。

此外还有一个 flex-nowrapf 类名的问题，我忘了修改了