### PR TITLE
fix: get store key

### DIFF
--- a/src/plugins/installPiniaPlugin.ts
+++ b/src/plugins/installPiniaPlugin.ts
@@ -171,7 +171,8 @@ function getStoreKey(state: StateTree, value: any, name:string[] = []): string {
         if (item === value) {
             return true;
         } else if (isObject(item)) {
-            return getStoreKey(item, value, name);
+            // @ts-ignore
+            return getStoreKey(item.value, value, name);
         } else if (Array.isArray(item)) {
             return item.includes(value);
         } else {


### PR DESCRIPTION
如果使用pnpm安装模块，会由于无限递归导致堆错误；但是使用yarn并没有该错误。
在检索store的key过程中，可以优化减少递归次数，并解决该问题。